### PR TITLE
Development

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,14 @@ This is not a training that starts from scratch.
 If you plan to do Fortran programming in a Linux or HPC environment you should
 be familiar with these as well.
 
+For following along hands-on, you need
+* laptop or desktop with internet access.
+* a Fortran compiler, either
+  * on a system set up so you can connect to an HPC system, an account on an HPC
+    system (e.g., VSC, CECI, ...), compute credits if that is required to run
+    jobs on the HPC system if you want to use an HPC system, or
+  * on your own system.
+
 
 ## Level
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,2 @@
+title: "Fortran for programmers"
 theme: jekyll-theme-slate


### PR DESCRIPTION
## Summary by Sourcery

Document prerequisites for hands-on participation and set the documentation site title.

Documentation:
- Add explicit hardware, connectivity, and compiler requirements for following the training hands-on.
- Set the documentation site title to “Fortran for programmers”.